### PR TITLE
add index to visit_history

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -28,6 +28,7 @@ restart-mysql:
 	sudo rsync -av ../conf/mysql/ /etc/mysql/
 	sudo systemctl restart mysql.service
 	sudo systemctl status mysql.service | tail -n 5
+	../sql/alter.sh
 
 init.config:
 	mkdir -p ../conf

--- a/sql/alter.sh
+++ b/sql/alter.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -ex
+cd `dirname $0`
+
+ISUCON_DB_HOST=${ISUCON_DB_HOST:-127.0.0.1}
+ISUCON_DB_PORT=${ISUCON_DB_PORT:-3306}
+ISUCON_DB_USER=${ISUCON_DB_USER:-isucon}
+ISUCON_DB_PASSWORD=${ISUCON_DB_PASSWORD:-isucon}
+ISUCON_DB_NAME=${ISUCON_DB_NAME:-isuports}
+
+# MySQLを初期化
+mysql -u"$ISUCON_DB_USER" \
+		-p"$ISUCON_DB_PASSWORD" \
+		--host "$ISUCON_DB_HOST" \
+		--port "$ISUCON_DB_PORT" \
+		"$ISUCON_DB_NAME" < alter.sql

--- a/sql/alter.sql
+++ b/sql/alter.sql
@@ -1,0 +1,2 @@
+DROP INDEX `tenant_compet_player_id_idx` ON `visit_history`;
+ALTER TABLE `visit_history` ADD INDEX `tenant_compet_player_id_idx` (`tenant_id`, `competition_id`, `player_id`);

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -2,9 +2,3 @@ DELETE FROM tenant WHERE id > 100;
 DELETE FROM visit_history WHERE created_at >= '1654041600';
 UPDATE id_generator SET id=2678400000 WHERE stub='a';
 ALTER TABLE id_generator AUTO_INCREMENT=2678400000;
-
--- index作成に時間がかかる場合は初期化がタイムアウトになって負荷テストが実行されない。
--- 本当は複合indexを貼りたい...
--- ALTER TABLE `visit_history` ADD INDEX `tenant_compet_player_id_idx` (`tenant_id`, `competition_id`, `player_id`);
-DROP INDEX `player_id_idx` ON `visit_history`;
-ALTER TABLE `visit_history` ADD INDEX `player_id_idx` ( `player_id`);


### PR DESCRIPTION
とりあえず最初のトップクエリに効くindexを追加。
```
04:40:20.277369 SCORE: 2967 (+2967 0(0%))
[ADMIN] 04:40:20.277463 score.ScoreTable{
  "GET /api/admin/tenants/billing":                         32,
  "GET /api/organizer/billing":                             20,
  "GET /api/organizer/players/list":                        30,
  "GET /api/player/competition/:competition_id/ranking":    649,
  "GET /api/player/competitions":                           128,
  "GET /api/player/player/:player_name":                    568,
  "POST /api/admin/tenants/add":                            3,
  "POST /api/organizer/competition/:competition_id/finish": 37,
  "POST /api/organizer/competition/:competition_id/score":  48,
  "POST /api/organizer/competitions/add":                   41,
  "POST /api/organizer/player/:player_name/disqualified":   10,
  "POST /api/organizer/players/add":                        6,
}
```

before
```
# Profile
# Rank Query ID                      Response time  Calls R/Call V/M   Ite
# ==== ============================= ============== ===== ====== ===== ===
#    1 0x676347F321DB8BC7FCB05D49... 118.2362 48.2%  1456 0.0812  0.05 SELECT visit_history
#    2 0x94A9E43DFAAFA029A1FC19A5... 115.6572 47.2%  7936 0.0146  0.00 REPLACE id_generator
# MISC 0xMISC                         11.2632  4.6% 26657 0.0004   0.0 <12 ITEMS>

# Query 1: 17.98 QPS, 1.46x concurrency, ID 0x676347F321DB8BC7FCB05D4948FC2248 at byte 4124077
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.05
# Time range: 2024-11-10T14:55:16 to 2024-11-10T14:56:37
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          4    1456
# Exec time     48    118s   213us   407ms    81ms   208ms    67ms    61ms
# Lock time      0     3ms     1us   514us     2us     2us    12us     1us
# Rows sent     97 123.54k       0     199   86.88  174.84   51.37   76.28
# Rows examine  89  26.91M       0  49.19k  18.92k  40.32k  12.40k  14.47k
# Query size    13 203.33k     142     144  143.00  136.99    0.69  136.99
# String:
# Databases    isuports
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us  #
#   1ms  #######
#  10ms  ################################################################
# 100ms  ####################################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuports` LIKE 'visit_history'\G
#    SHOW CREATE TABLE `isuports`.`visit_history`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT player_id, MIN(created_at) AS min_created_at FROM visit_history WHERE tenant_id = 36 AND competition_id = '20913b0e8' GROUP BY player_id\G

```

after
```
# Profile
# Rank Query ID                      Response time  Calls R/Call V/M   Ite
# ==== ============================= ============== ===== ====== ===== ===
#    1 0x94A9E43DFAAFA029A1FC19A5... 120.6304 55.3%  8552 0.0141  0.00 REPLACE id_generator
#    2 0x676347F321DB8BC7FCB05D49...  88.4976 40.6%  2174 0.0407  0.02 SELECT visit_history
# MISC 0xMISC                          8.8248  4.0% 30811 0.0003   0.0 <15 ITEMS>
```

explain

```
mysql> explain SELECT player_id, MIN(created_at) AS min_created_at FROM visit_history WHERE tenant_id = 36 AND competition_id = '20913b0e8' GROUP BY player_id\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: visit_history
   partitions: NULL
         type: ref
possible_keys: tenant_id_idx
          key: tenant_id_idx
      key_len: 8
          ref: const
         rows: 84748
     filtered: 10.00
        Extra: Using where; Using temporary
1 row in set, 1 warning (0.00 sec)

mysql> explain SELECT player_id, MIN(created_at) AS min_created_at FROM visit_history WHERE tenant_id = 36 AND competition_id = '20913b0e8' GROUP BY player_id\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: visit_history
   partitions: NULL
         type: ref
possible_keys: tenant_id_idx,tenant_compet_player_id_idx
          key: tenant_compet_player_id_idx
      key_len: 1030
          ref: const,const
         rows: 2670
     filtered: 100.00
        Extra: NULL
1 row in set, 1 warning (0.00 sec)


```