### PR TITLE
dispense id without db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 sqlite-trace.log
 survey
 go/isuports
+tenant_db

--- a/go/isuports.go
+++ b/go/isuports.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -47,6 +48,9 @@ var (
 	adminDB *sqlx.DB
 
 	sqliteDriverName = "sqlite3"
+
+	uid = 1
+	mu  sync.Mutex
 )
 
 // 環境変数を取得する、なければデフォルト値を返す
@@ -98,29 +102,11 @@ func createTenantDB(id int64) error {
 }
 
 // システム全体で一意なIDを生成する
-func dispenseID(ctx context.Context) (string, error) {
-	var id int64
-	var lastErr error
-	for i := 0; i < 100; i++ {
-		var ret sql.Result
-		ret, err := adminDB.ExecContext(ctx, "REPLACE INTO id_generator (stub) VALUES (?);", "a")
-		if err != nil {
-			if merr, ok := err.(*mysql.MySQLError); ok && merr.Number == 1213 { // deadlock
-				lastErr = fmt.Errorf("error REPLACE INTO id_generator: %w", err)
-				continue
-			}
-			return "", fmt.Errorf("error REPLACE INTO id_generator: %w", err)
-		}
-		id, err = ret.LastInsertId()
-		if err != nil {
-			return "", fmt.Errorf("error ret.LastInsertId: %w", err)
-		}
-		break
-	}
-	if id != 0 {
-		return fmt.Sprintf("%x", id), nil
-	}
-	return "", lastErr
+func dispenseID() (string, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	uid += 1
+	return fmt.Sprintf("%x", uid), nil
 }
 
 // 全APIにCache-Control: privateを設定する
@@ -793,7 +779,7 @@ func playersAddHandler(c echo.Context) error {
 
 	pds := make([]PlayerDetail, 0, len(displayNames))
 	for _, displayName := range displayNames {
-		id, err := dispenseID(ctx)
+		id, err := dispenseID()
 		if err != nil {
 			return fmt.Errorf("error dispenseID: %w", err)
 		}
@@ -911,7 +897,7 @@ func competitionsAddHandler(c echo.Context) error {
 	title := c.FormValue("title")
 
 	now := time.Now().Unix()
-	id, err := dispenseID(ctx)
+	id, err := dispenseID()
 	if err != nil {
 		return fmt.Errorf("error dispenseID: %w", err)
 	}
@@ -1081,7 +1067,7 @@ func competitionScoreHandler(c echo.Context) error {
 				fmt.Sprintf("error strconv.ParseUint: scoreStr=%s, %s", scoreStr, err),
 			)
 		}
-		id, err := dispenseID(ctx)
+		id, err := dispenseID()
 		if err != nil {
 			return fmt.Errorf("error dispenseID: %w", err)
 		}


### PR DESCRIPTION
次なるトップクエリ対策。
uid生成のためにinsertを繰り返していたので、アプリロジック内でuidを払い出すようにした。

before

```
# Profile
# Rank Query ID                      Response time  Calls R/Call V/M   Ite
# ==== ============================= ============== ===== ====== ===== ===
#    1 0x94A9E43DFAAFA029A1FC19A5... 188.2441 84.8%  9447 0.0199  0.01 REPLACE id_generator
#    2 0x676347F321DB8BC7FCB05D49...  23.8869 10.8%  3827 0.0062  0.08 SELECT visit_history
# MISC 0xMISC                          9.9317  4.5% 37077 0.0003   0.0 <18 ITEMS>

# Query 1: 134.96 QPS, 2.69x concurrency, ID 0x94A9E43DFAAFA029A1FC19A5563AD0F5 at byte 5231664
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-28T04:14:31 to 2024-11-28T04:15:41
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         18    9447
# Exec time     84    188s     1ms   211ms    20ms    38ms    12ms    17ms
# Lock time     99    120s       0   156ms    13ms    30ms    11ms    11ms
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size    18 415.15k      45      45      45      45       0      45
# String:
# Databases    isuports
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ##########
#  10ms  ################################################################
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuports` LIKE 'id_generator'\G
#    SHOW CREATE TABLE `isuports`.`id_generator`\G
REPLACE INTO id_generator (stub) VALUES ('a')\G

```

after
```
# Profile
# Rank Query ID                      Response time Calls R/Call V/M   Item
# ==== ============================= ============= ===== ====== ===== ====
#    1 0x676347F321DB8BC7FCB05D49... 45.2361 74.8%  4753 0.0095  0.17 SELECT visit_history
#    2 0x2E69352DE16B15042A121750... 12.4975 20.7%  1457 0.0086  0.00 INSERT visit_history
# MISC 0xMISC                         2.7696  4.6% 26921 0.0001   0.0 <11 ITEMS>
```