### PR TITLE
ttl 60

### DIFF
--- a/go/isuports.go
+++ b/go/isuports.go
@@ -557,7 +557,7 @@ func billingReportByCompetition(ctx context.Context, tenantDB dbOrTx, tenantID i
 			if err != nil {
 				return nil, fmt.Errorf("error marshal to json: %w", err)
 			}
-			err = rdb.Set(ctx, key, _vhs, 10*time.Second).Err()
+			err = rdb.Set(ctx, key, _vhs, 60*time.Second).Err()
 			if err != nil {
 				return nil, fmt.Errorf("error redis set: %w", err)
 			}


### PR DESCRIPTION
最終スコア
```
05:22:11.877093 Error 5 (Critical:0)
05:22:11.877095 PASSED: true
05:22:11.877098 SCORE: 5100 (+5368 -268(5%))
[ADMIN] 05:22:11.877172 score.ScoreTable{
  "GET /api/admin/tenants/billing":                         36,
  "GET /api/organizer/billing":                             36,
  "GET /api/organizer/players/list":                        49,
  "GET /api/player/competition/:competition_id/ranking":    1298,
  "GET /api/player/competitions":                           222,
  "GET /api/player/player/:player_name":                    1278,
  "POST /api/admin/tenants/add":                            3,
  "POST /api/organizer/competition/:competition_id/finish": 61,
  "POST /api/organizer/competition/:competition_id/score":  76,
  "POST /api/organizer/competitions/add":                   64,
  "POST /api/organizer/player/:player_name/disqualified":   15,
  "POST /api/organizer/players/add":                        7,
}
```

キャッシュヒットを上げるためにttlを調整してみた。10秒の時点でエラーが5で、3分にすると5を超えてきたので1分にとどめておく。スコアに変化はないが、dbへのリクエストが1700になった。

before
```
# Profile
# Rank Query ID                      Response time Calls R/Call V/M   Item
# ==== ============================= ============= ===== ====== ===== ====
#    1 0x676347F321DB8BC7FCB05D49... 25.5799 64.6%  3071 0.0083  0.10 SELECT visit_history
#    2 0x2E69352DE16B15042A121750... 11.5610 29.2%  1275 0.0091  0.00 INSERT visit_history
#    3 0x3289E87E94D5A82E348974B3...  1.3515  3.4%     1 1.3515  0.00 DELETE visit_history
# MISC 0xMISC                         1.1259  2.8% 22676 0.0000   0.0 <10 ITEMS>
```

after
```
# Profile
# Rank Query ID                      Response time Calls R/Call V/M   Item
# ==== ============================= ============= ===== ====== ===== ====
#    1 0x2E69352DE16B15042A121750... 11.6325 52.9%  1338 0.0087  0.00 INSERT visit_history
#    2 0x676347F321DB8BC7FCB05D49...  7.8919 35.9%  1253 0.0063  0.10 SELECT visit_history
#    3 0x3289E87E94D5A82E348974B3...  1.4728  6.7%     1 1.4728  0.00 DELETE visit_history
# MISC 0xMISC                         1.0070  4.6% 18935 0.0001   0.0 <10 ITEMS>
```