### PR TITLE
remove unused index

### DIFF
--- a/sql/alter.sql
+++ b/sql/alter.sql
@@ -1,2 +1,6 @@
 DROP INDEX `tenant_compet_player_id_idx` ON `visit_history`;
 ALTER TABLE `visit_history` ADD INDEX `tenant_compet_player_id_idx` (`tenant_id`, `competition_id`, `player_id`);
+
+-- tenant_id 単体でselectされていないので消す
+ALTER TABLE `visit_history` ADD INDEX `tenant_id_idx` (`tenant_id`);
+DROP INDEX `tenant_id_idx` ON `visit_history`;


### PR DESCRIPTION
最終スコア
```
08:38:35.505502 Error 4 (Critical:0)
08:38:35.505505 PASSED: true
08:38:35.505507 SCORE: 5348 (+5570 -222(4%))
[ADMIN] 08:38:35.505583 score.ScoreTable{
  "GET /api/admin/tenants/billing":                         38,
  "GET /api/organizer/billing":                             36,
  "GET /api/organizer/players/list":                        51,
  "GET /api/player/competition/:competition_id/ranking":    1321,
  "GET /api/player/competitions":                           229,
  "GET /api/player/player/:player_name":                    1396,
  "POST /api/admin/tenants/add":                            3,
  "POST /api/organizer/competition/:competition_id/finish": 61,
  "POST /api/organizer/competition/:competition_id/score":  78,
  "POST /api/organizer/competitions/add":                   66,
  "POST /api/organizer/player/:player_name/disqualified":   15,
  "POST /api/organizer/players/add":                        8,
}
```

visit_historyへのinsertがトップクエリになったので、不要なindexを消してinsert時のindex更新コストを抑える。気持ちexec timeの最大値のオーダーを10msに下げられた。

before
```
# Profile
# Rank Query ID                      Response time Calls R/Call V/M   Item
# ==== ============================= ============= ===== ====== ===== ====
#    1 0x2E69352DE16B15042A121750... 12.1343 51.5%  1282 0.0095  0.01 INSERT visit_history
#    2 0x676347F321DB8BC7FCB05D49...  9.0153 38.2%  1259 0.0072  0.12 SELECT visit_history
#    3 0x3289E87E94D5A82E348974B3...  1.4463  6.1%     1 1.4463  0.00 DELETE visit_history
# MISC 0xMISC                         0.9757  4.1% 19707 0.0000   0.0 <10 ITEMS>

# Query 1: 18.58 QPS, 0.18x concurrency, ID 0x2E69352DE16B15042A1217500A0400FE at byte 1746776
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2024-11-29T08:07:22 to 2024-11-29T08:08:31
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          5    1282
# Exec time     51     12s     2ms   237ms     9ms    14ms    10ms     8ms
# Lock time     14     1ms       0    59us       0     1us     1us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size    17 176.89k     135     150  141.29  143.84    3.14  136.99
# String:
# Databases    isuports
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ##############################
# 100ms  #
#    1s
#  10s+
```

after
```
# Profile
# Rank Query ID                      Response time Calls R/Call V/M   Item
# ==== ============================= ============= ===== ====== ===== ====
#    1 0x2E69352DE16B15042A121750... 11.6766 49.7%  1387 0.0084  0.00 INSERT visit_history
#    2 0x676347F321DB8BC7FCB05D49...  9.3085 39.6%  1252 0.0074  0.14 SELECT visit_history
#    3 0x3289E87E94D5A82E348974B3...  1.4558  6.2%     1 1.4558  0.00 DELETE visit_history
# MISC 0xMISC                         1.0428  4.4% 19970 0.0001   0.0 <10 ITEMS>

# Query 1: 21.02 QPS, 0.18x concurrency, ID 0x2E69352DE16B15042A1217500A0400FE at byte 2714850
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-11-29T08:37:29 to 2024-11-29T08:38:35
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          6    1387
# Exec time     49     12s     2ms    55ms     8ms    14ms     3ms     8ms
# Lock time     14     1ms       0   129us       0     1us     3us     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size    18 191.17k     135     150  141.13  143.84    3.04  136.99
# String:
# Databases    isuports
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ####################
# 100ms
#    1s
#  10s+
```